### PR TITLE
Add missing header in layoutselector.h

### DIFF
--- a/src/lib/layoutselector.h
+++ b/src/lib/layoutselector.h
@@ -24,6 +24,7 @@
 #include <QStringListModel>
 #include <QWidget>
 #include <fcitxqtdbustypes.h>
+#include <memory>
 
 class QDBusPendingCallWatcher;
 


### PR DESCRIPTION
```
/build/kcm-fcitx5-zF36QT/kcm-fcitx5-0.0~git20200321.d33ce56/src/lib/layoutselector.h:65:10: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   65 |     std::unique_ptr<Ui::LayoutSelector> ui_;
      |          ^~~~~~~~~~
/build/kcm-fcitx5-zF36QT/kcm-fcitx5-0.0~git20200321.d33ce56/src/lib/layoutselector.h:27:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   26 | #include <fcitxqtdbustypes.h>
  +++ |+#include <memory>
```