### PR TITLE
Make layout more in line with other KCM modules.

### DIFF
--- a/src/configtool/mainwindow.cpp
+++ b/src/configtool/mainwindow.cpp
@@ -25,14 +25,14 @@ MainWindow::MainWindow(QWidget *parent)
         qCDebug(KCM_FCITX5) << "IMPage changed";
         emit changed(true);
     });
-    pageWidget->addTab(addonPage_, _("Addon"));
+    pageWidget->addTab(addonPage_, _("Addons"));
     connect(addonPage_, &AddonSelector::changed, this, [this]() {
         qCDebug(KCM_FCITX5) << "AddonSelector changed";
         emit changed(true);
     });
     auto configPageWrapper = new VerticalScrollArea;
     configPageWrapper->setWidget(configPage_);
-    pageWidget->addTab(configPageWrapper, _("Global Config"));
+    pageWidget->addTab(configPageWrapper, _("Global Options"));
     connect(configPage_, &ConfigWidget::changed, this,
             [this]() { emit changed(true); });
 

--- a/src/kcm/main.cpp
+++ b/src/kcm/main.cpp
@@ -34,7 +34,7 @@ FcitxModule::FcitxModule(QObject *parent, const QVariantList &args)
     qmlRegisterAnonymousType<LanguageModel>("", 1);
 
     KAboutData *about = new KAboutData(
-        "kcm_fcitx5", i18n("Fcitx 5 Configuration Module"), PROJECT_VERSION,
+        "kcm_fcitx5", i18n("Fcitx 5"), PROJECT_VERSION,
         i18n("Configure Fcitx 5"), KAboutLicense::GPL_V2,
         i18n("Copyright 2017 Xuetian Weng"), QString(), QString(),
         "wengxt@gmail.com");

--- a/src/kcm/package/contents/ui/main.qml
+++ b/src/kcm/package/contents/ui/main.qml
@@ -150,24 +150,21 @@ KCM.ScrollViewKCM {
 
     footer: RowLayout {
         enabled: kcm.availability
+        Button {
+            text: i18n("Configure global options...")
+            icon.name: "configure"
+            onClicked: kcm.pushConfigPage(i18n("Global Options"),
+                                          "fcitx://config/global")
+        }
+        Button {
+            text: i18n("Configure addons...")
+            icon.name: "configure"
+            onClicked: kcm.push("AddonPage.qml")
+        }
         Item {
             Layout.fillWidth: true
         }
         Button {
-            Layout.alignment: Qt.AlignRight
-            text: i18n("Config global options...")
-            icon.name: "configure"
-            onClicked: kcm.pushConfigPage(i18n("Global Config"),
-                                          "fcitx://config/global")
-        }
-        Button {
-            Layout.alignment: Qt.AlignRight
-            text: i18n("Config addons...")
-            icon.name: "configure"
-            onClicked: kcm.push("AddonPage.qml")
-        }
-        Button {
-            Layout.alignment: Qt.AlignRight
             text: i18n("Add...")
             icon.name: "list-add-symbolic"
             onClicked: kcm.push("AddIMPage.qml")


### PR DESCRIPTION
The main reference is the "Application Style" page.

Layout changes:

- Buttons that lead to configuration pages are moved to the left.
- "Layout.alignment" is not needed so removed.

Text changes:

- Page title trimmed.
- "config" is not a word; replaced with "configuration" or "option"
  according to context.
- "Addon" -> "Addons" in tab title.